### PR TITLE
Terraform Example Fixes

### DIFF
--- a/Basic-server/connect.tf
+++ b/Basic-server/connect.tf
@@ -1,14 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.33.0"
+    }
+  }
+}
 provider "aws" {
     #tenant
     access_key = "${var.accesskey}"
-    secret_key ="${var.secretkey}"
+    secret_key = "${var.secretkey}"
     #zCloud endpoints
     endpoints {
-        ec2 = "https://${var.zcloud_ip}/api/v2/aws/ec2"
-        }
+        ec2 = "https://${var.zcloud_ip}/api/v2/ec2"
+        iam = "https://${var.zcloud_ip}/api/v2/aws/iam"
+    }
+    insecure = "true"
     skip_metadata_api_check = true
     skip_credentials_validation = true
     skip_requesting_account_id = true
-    version = "3.33"
     region = "us-east-1"
-  }
+}

--- a/Basic-server/connect.tf
+++ b/Basic-server/connect.tf
@@ -6,18 +6,19 @@ terraform {
     }
   }
 }
+
 provider "aws" {
     #tenant
-    access_key = "${var.accesskey}"
-    secret_key = "${var.secretkey}"
+    access_key = var.accesskey
+    secret_key = var.secretkey
     #zCloud endpoints
     endpoints {
         ec2 = "https://${var.zcloud_ip}/api/v2/ec2"
         iam = "https://${var.zcloud_ip}/api/v2/aws/iam"
     }
-    insecure = "true"
-    skip_metadata_api_check = true
+    insecure                    = "true"
+    skip_metadata_api_check     = true
     skip_credentials_validation = true
-    skip_requesting_account_id = true
-    region = "us-east-1"
+    skip_requesting_account_id  = true
+    region                      = "us-east-1"
 }

--- a/Basic-server/network.tf
+++ b/Basic-server/network.tf
@@ -6,7 +6,7 @@ data "http" "myip" {
 resource "aws_security_group" "allow_all" {
   vpc_id      = var.vpc
   name        = "allow_all"
-  description = "Allow all traffic"
+  description = "Allow all outbout, allow only me inbound"
 
   ingress {
     from_port   = 0

--- a/Basic-server/network.tf
+++ b/Basic-server/network.tf
@@ -1,13 +1,18 @@
+// determine the external IP of the system running OpenTofu/Terraform
+data "http" "myip" {
+  url = "https://ip.rights.ninja/ip"
+}
+
 resource "aws_security_group" "allow_all" {
-  name        = "allow_all3"
+  vpc_id      = var.vpc
+  name        = "allow_all"
   description = "Allow all traffic"
-  vpc_id      = "${var.vpc}"
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"] // Allow ingress only from external IP of the system running OpenTofu/Terraform
   }
 
   egress {

--- a/Basic-server/server.tf
+++ b/Basic-server/server.tf
@@ -1,25 +1,25 @@
 resource "aws_instance" "server" {
-  count = "${var.quantity-server}"
-  ami = "${var.ami}"
-  instance_type = "${var.instance}"
-  subnet_id = "${var.subnet}"
-  vpc_security_group_ids = [aws_security_group.allow_all.id]
-  key_name = "${var.keyname}"
+  count                   = var.quantity-server
+  ami                     = var.ami
+  instance_type           = var.instance
+  subnet_id               = var.subnet
+  vpc_security_group_ids  = [aws_security_group.allow_all.id]
+  key_name                = var.keyname
   root_block_device {
-    volume_size           = "10"
+    volume_size = "10"
   }
   tags = {
-  Name     = "${var.servername}${count.index}"
+    Name = "${var.servername}${count.index}"
   }
 }
 
 resource "aws_eip" "server" {
-  count = "${var.quantity-server}"
-  instance = aws_instance.server[count.index].id
+  count     = var.quantity-server
+  instance  = aws_instance.server[count.index].id
 }
 
 resource "aws_eip_association" "eip_server" {
-  count = "${var.quantity-server}"
+  count         = var.quantity-server
   instance_id   = aws_instance.server[count.index].id
   allocation_id = aws_eip.server[count.index].id
 }

--- a/Basic-server/server.tf
+++ b/Basic-server/server.tf
@@ -18,7 +18,6 @@ resource "aws_network_interface" "server" {
 }
 resource "aws_eip" "server" {
   count = "${var.quantity-server}"
-  vpc = true
 }
 resource "aws_eip_association" "eip_server" {
   instance_id        = "${element(aws_instance.server.*.id,count.index)}"

--- a/Basic-server/server.tf
+++ b/Basic-server/server.tf
@@ -12,16 +12,14 @@ resource "aws_instance" "server" {
   Name     = "${var.servername}${count.index}"
   }
 }
-resource "aws_network_interface" "server" {
-  subnet_id       = "${var.subnet}"
-  security_groups = ["${aws_security_group.allow_all.id}"]
-}
+
 resource "aws_eip" "server" {
   count = "${var.quantity-server}"
+  instance = aws_instance.server[count.index].id
 }
+
 resource "aws_eip_association" "eip_server" {
-  instance_id        = "${element(aws_instance.server.*.id,count.index)}"
-  network_interface_id = aws_network_interface.server.id
-  allocation_id = "${element(aws_eip.server.*.id,count.index)}"
   count = "${var.quantity-server}"
+  instance_id   = aws_instance.server[count.index].id
+  allocation_id = aws_eip.server[count.index].id
 }

--- a/Basic-server/variables.tf
+++ b/Basic-server/variables.tf
@@ -1,11 +1,11 @@
 variable "accesskey" {
-  default = "your access key"
+  type = string  // Your access Key
 }
 variable "secretkey" {
-  default = "your private key"
+  type = string  // Your secret Key
 }
 variable "zcloud_ip" {
-  default = "your zcloud URL"
+  type = string  // FQDN or IP of Zadara Compute cloud (eg, compute-example-01.zadara.com)
 }
 variable "quantity-server" {
   default = 2
@@ -14,17 +14,17 @@ variable "servername" {
   default = "server-"
 }
 variable "keyname" {
-  default = "your keyname"
+  type = string  // Name of Key Pair to be used for VM
 }
 variable "instance" {
   default = "z4.large"
 }
 variable "ami" {
-    default = "your ami ID starts with ami-"
+  type = string  // Image ID, starts with ami-
 }
 variable "vpc" {
-  default = "your VPC ID starts with vpc-"
+  type = string  // VPC ID, starts with vpc-
 }
 variable "subnet" {
-  default = "your Subnet ID starts with subnet-"
+  type = string  // Subnet ID, starts with subnet-
 }

--- a/k8s-server_with_csi/connect.tf
+++ b/k8s-server_with_csi/connect.tf
@@ -1,16 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.33.0"
+    }
+  }
+}
 provider "aws" {
     #tenant
     access_key = "${var.accesskey}"
-    secret_key ="${var.secretkey}"
+    secret_key = "${var.secretkey}"
     #zCloud endpoints
     endpoints {
-        ec2 = "https://${var.zcloud_ip}/api/v2/aws/ec2"
-        elb = "https://${var.zcloud_ip}/api/v2/aws/elb"
-        route53 = "https://${var.zcloud_ip}/api/v2/aws/route53"
-        }
+        ec2 = "https://${var.zcloud_ip}/api/v2/ec2"
+        iam = "https://${var.zcloud_ip}/api/v2/aws/iam"
+    }
+    insecure = "true"
     skip_metadata_api_check = true
     skip_credentials_validation = true
     skip_requesting_account_id = true
-    version = "3.33"
     region = "us-east-1"
-  }
+}

--- a/k8s-server_with_csi/network.tf
+++ b/k8s-server_with_csi/network.tf
@@ -1,3 +1,8 @@
+// determine the external IP of the system running OpenTofu/Terraform
+data "http" "myip" {
+  url = "https://ip.rights.ninja/ip"
+}
+
 resource "aws_security_group" "allow_all" {
   name        = "k8s"
   description = "k8s traffic"
@@ -7,7 +12,7 @@ resource "aws_security_group" "allow_all" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"] // Allow ingress only from external IP of the system running OpenTofu/Terraform
   }
 
   ingress {

--- a/k8s/connect.tf
+++ b/k8s/connect.tf
@@ -1,16 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.33.0"
+    }
+  }
+}
 provider "aws" {
     #tenant
     access_key = "${var.accesskey}"
-    secret_key ="${var.secretkey}"
+    secret_key = "${var.secretkey}"
     #zCloud endpoints
     endpoints {
-        ec2 = "https://${var.zcloud_ip}/api/v2/aws/ec2"
-        elb = "https://${var.zcloud_ip}/api/v2/aws/elb"
-        route53 = "https://${var.zcloud_ip}/api/v2/aws/route53"
-        }
+        ec2 = "https://${var.zcloud_ip}/api/v2/ec2"
+        iam = "https://${var.zcloud_ip}/api/v2/aws/iam"
+    }
+    insecure = "true"
     skip_metadata_api_check = true
     skip_credentials_validation = true
     skip_requesting_account_id = true
-    version = "3.33"
     region = "us-east-1"
-  }
+}

--- a/k8s/network.tf
+++ b/k8s/network.tf
@@ -1,13 +1,18 @@
+// determine the external IP of the system running OpenTofu/Terraform
+data "http" "myip" {
+  url = "https://ip.rights.ninja/ip"
+}
+
 resource "aws_security_group" "allow_all" {
   name        = "allow_all_k8s-test"
-  description = "Allow all traffic"
+  description = "Allow all outbout, allow only me inbound"
   vpc_id      = "${var.vpc}"
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"] // Allow ingress only from external IP of the system running OpenTofu/Terraform
   }
 
   egress {

--- a/loadbalancer/connect.tf
+++ b/loadbalancer/connect.tf
@@ -1,14 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.33.0"
+    }
+  }
+}
 provider "aws" {
     #tenant
     access_key = "${var.accesskey}"
     secret_key = "${var.secretkey}"
     #zCloud endpoints
     endpoints {
-        ec2 = "https://${var.zcloud_ip}/api/v2/aws/ec2"
-        elb = "https://${var.zcloud_ip}/api/v2/aws/elbv2"
-        }
+        ec2 = "https://${var.zcloud_ip}/api/v2/ec2"
+        iam = "https://${var.zcloud_ip}/api/v2/aws/iam"
+    }
+    insecure = "true"
     skip_metadata_api_check = true
     skip_credentials_validation = true
     skip_requesting_account_id = true
     region = "us-east-1"
-  }
+}

--- a/loadbalancer/network.tf
+++ b/loadbalancer/network.tf
@@ -1,3 +1,8 @@
+// determine the external IP of the system running OpenTofu/Terraform
+data "http" "myip" {
+  url = "https://ip.rights.ninja/ip"
+}
+
 resource "aws_security_group" "nginx" {
   name   = "instance-sg"
   vpc_id = "${var.vpc}"
@@ -31,7 +36,7 @@ resource "aws_security_group" "elb" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"] // Allow ingress only from external IP of the system running OpenTofu/Terraform
   }
 
   egress {


### PR DESCRIPTION
The terraform examples included a few significant logical and security issues, as well as a number of deprecated parameters.

This PR addresses the following:

- fixed broken `Basic-server` example
- added a secure Ingress rule for Security Group
- removed invalid default variables
- removed/updated a number of deprecated parameters
- cleaned up formatting of  `Basic-server` example